### PR TITLE
fix shifter for mul_rd signal

### DIFF
--- a/rtl/mdu_top.v
+++ b/rtl/mdu_top.v
@@ -59,7 +59,7 @@ module mdu_top
   end
 
   assign mul_ready = mul_done & valid;
-  assign mul_rd = is_mulh ? rd >> 32 : rd;
+  assign mul_rd = is_mulh ? rd[(2*WIDTH)-1:WIDTH] : rd[WIDTH-1:0];
 
   // DIV STARTS //  
   // Taken from picorv32 //


### PR DESCRIPTION
the logic of selecting the high/low part of multiplication result has been optimized.

before changes:
LUT 462
FF	230	
DSP	4	

After changes:
LUT	438	
FF	213	
DSP	3	

The difference: LUT -24 ; FF -13; DSP-1; Tested at Artix-7